### PR TITLE
Set "Serial" to something, and expose some advanced options

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -2,6 +2,81 @@
 
 menu.cpu=Processor
 
+menu.optimization=Optimize for
+
+menu.defaultserial=Default Serial Port
+
+menu.experimentalsavings=Experimental Size Reductions
+
+##############################################################
+
+micro.name=Arduino Micro (LUFA)
+
+micro.vid.0=0x2341
+micro.pid.0=0x0037
+micro.vid.1=0x2341
+micro.pid.1=0x8037
+micro.vid.2=0x2A03
+micro.pid.2=0x0037
+micro.vid.3=0x2A03
+micro.pid.3=0x8037
+micro.vid.4=0x2341
+micro.pid.4=0x0237
+micro.vid.5=0x2341
+micro.pid.5=0x8237
+
+micro.upload.tool=avrdude
+micro.upload.protocol=avr109
+micro.upload.maximum_size=28672
+micro.upload.maximum_data_size=2560
+micro.upload.speed=57600
+micro.upload.disable_flushing=true
+micro.upload.use_1200bps_touch=true
+micro.upload.wait_for_upload_port=true
+
+micro.bootloader.tool=avrdude
+micro.bootloader.low_fuses=0xff
+micro.bootloader.high_fuses=0xd8
+micro.bootloader.extended_fuses=0xcb
+micro.bootloader.file=caterina/Caterina-Micro.hex
+micro.bootloader.unlock_bits=0x3F
+micro.bootloader.lock_bits=0x2F
+
+micro.build.mcu=atmega32u4
+micro.build.f_cpu=16000000L
+micro.build.vid=0x2341
+micro.build.pid=0x8037
+micro.build.usb_product="Arduino Micro"
+micro.build.board=AVR_MICRO
+micro.build.core=arduino
+micro.build.variant=micro
+micro.build.extra_flags={build.usb_flags}
+
+micro.build.optimization_flags=-Os
+
+micro.menu.optimization.size=Size (Os)
+micro.menu.optimization.size.build.optimization_flags=-Os
+micro.menu.optimization.balance=Balance (O2)
+micro.menu.optimization.balance.build.optimization_flags=-O2
+micro.menu.optimization.speed=Speed (O3)
+micro.menu.optimization.speed.build.optimization_flags=-O3
+
+micro.build.serial_flags=-DSerial=Serial1
+
+micro.menu.defaultserial.hwserial=Hardware Serial (aka Serial1)
+micro.menu.defaultserial.hwserial.build.serial_flags=-DSerial=Serial1
+micro.menu.defaultserial.vserial1=Virtual Serial 1 (SerialU1)
+micro.menu.defaultserial.vserial1.build.serial_flags=-DSerial=SerialU1
+micro.menu.defaultserial.vserial2=Virtual Serial 2 (SerialU2)
+micro.menu.defaultserial.vserial2.build.serial_flags=-DSerial=SerialU2
+
+micro.menu.experimentalsavings.safest=No extra parameters (Safest)
+micro.menu.experimentalsavings.safest.build.savings_flags=
+micro.menu.experimentalsavings.knowngood=-fno-devirtualize -fno-use-cxa-atexit (Known to work)
+micro.menu.experimentalsavings.knowngood.build.savings_flags=-fno-devirtualize -fno-use-cxa-atexit
+micro.menu.experimentalsavings.novirt=-fno-devirtualize (Should be safe)
+micro.menu.experimentalsavings.novirt.build.savings_flags=-fno-devirtualize
+
 ##############################################################
 
 yun.name=Arduino Yún (LUFA)
@@ -43,6 +118,659 @@ yun.build.board=AVR_YUN
 yun.build.core=arduino
 yun.build.variant=yun
 yun.build.extra_flags={build.usb_flags}
+
+yun.build.optimization_flags=-Os
+
+yun.menu.optimization.size=Size (Os)
+yun.menu.optimization.size.build.optimization_flags=-Os
+yun.menu.optimization.balance=Balance (O2)
+yun.menu.optimization.balance.build.optimization_flags=-O2
+yun.menu.optimization.speed=Speed (O3)
+yun.menu.optimization.speed.build.optimization_flags=-O3
+
+yun.build.serial_flags=-DSerial=Serial1
+
+yun.menu.defaultserial.hwserial=Hardware Serial (aka Serial1)
+yun.menu.defaultserial.hwserial.build.serial_flags=-DSerial=Serial1
+yun.menu.defaultserial.vserial1=Virtual Serial 1 (SerialU1)
+yun.menu.defaultserial.vserial1.build.serial_flags=-DSerial=SerialU1
+yun.menu.defaultserial.vserial2=Virtual Serial 2 (SerialU2)
+yun.menu.defaultserial.vserial2.build.serial_flags=-DSerial=SerialU2
+
+yun.menu.experimentalsavings.safest=No extra parameters (Safest)
+yun.menu.experimentalsavings.safest.build.savings_flags=
+yun.menu.experimentalsavings.knowngood=-fno-devirtualize -fno-use-cxa-atexit (Known to work)
+yun.menu.experimentalsavings.knowngood.build.savings_flags=-fno-devirtualize -fno-use-cxa-atexit
+yun.menu.experimentalsavings.novirt=-fno-devirtualize (Should be safe)
+yun.menu.experimentalsavings.novirt.build.savings_flags=-fno-devirtualize
+
+
+##############################################################
+
+leonardo.name=Arduino Leonardo (LUFA)
+leonardo.vid.0=0x2341
+leonardo.pid.0=0x0036
+leonardo.vid.1=0x2341
+leonardo.pid.1=0x8036
+leonardo.vid.2=0x2A03
+leonardo.pid.2=0x0036
+leonardo.vid.3=0x2A03
+leonardo.pid.3=0x8036
+
+leonardo.upload.tool=avrdude
+leonardo.upload.protocol=avr109
+leonardo.upload.maximum_size=28672
+leonardo.upload.maximum_data_size=2560
+leonardo.upload.speed=57600
+leonardo.upload.disable_flushing=true
+leonardo.upload.use_1200bps_touch=true
+leonardo.upload.wait_for_upload_port=true
+
+leonardo.bootloader.tool=avrdude
+leonardo.bootloader.low_fuses=0xff
+leonardo.bootloader.high_fuses=0xd8
+leonardo.bootloader.extended_fuses=0xcb
+leonardo.bootloader.file=caterina/Caterina-Leonardo.hex
+leonardo.bootloader.unlock_bits=0x3F
+leonardo.bootloader.lock_bits=0x2F
+
+leonardo.build.mcu=atmega32u4
+leonardo.build.f_cpu=16000000L
+leonardo.build.vid=0x2341
+leonardo.build.pid=0x8036
+leonardo.build.usb_product="Arduino Leonardo"
+leonardo.build.board=AVR_LEONARDO
+leonardo.build.core=arduino
+leonardo.build.variant=leonardo
+leonardo.build.extra_flags={build.usb_flags}
+
+leonardo.build.optimization_flags=-Os
+
+leonardo.menu.optimization.size=Size (Os)
+leonardo.menu.optimization.size.build.optimization_flags=-Os
+leonardo.menu.optimization.balance=Balance (O2)
+leonardo.menu.optimization.balance.build.optimization_flags=-O2
+leonardo.menu.optimization.speed=Speed (O3)
+leonardo.menu.optimization.speed.build.optimization_flags=-O3
+
+leonardo.build.serial_flags=-DSerial=Serial1
+
+leonardo.menu.defaultserial.hwserial=Hardware Serial (aka Serial1)
+leonardo.menu.defaultserial.hwserial.build.serial_flags=-DSerial=Serial1
+leonardo.menu.defaultserial.vserial1=Virtual Serial 1 (SerialU1)
+leonardo.menu.defaultserial.vserial1.build.serial_flags=-DSerial=SerialU1
+leonardo.menu.defaultserial.vserial2=Virtual Serial 2 (SerialU2)
+leonardo.menu.defaultserial.vserial2.build.serial_flags=-DSerial=SerialU2
+
+leonardo.menu.experimentalsavings.safest=No extra parameters (Safest)
+leonardo.menu.experimentalsavings.safest.build.savings_flags=
+leonardo.menu.experimentalsavings.knowngood=-fno-devirtualize -fno-use-cxa-atexit (Known to work)
+leonardo.menu.experimentalsavings.knowngood.build.savings_flags=-fno-devirtualize -fno-use-cxa-atexit
+leonardo.menu.experimentalsavings.novirt=-fno-devirtualize (Should be safe)
+leonardo.menu.experimentalsavings.novirt.build.savings_flags=-fno-devirtualize
+
+
+##############################################################
+
+leonardoeth.name=Arduino Leonardo ETH (LUFA)
+leonardoeth.vid.0=0x2a03
+leonardoeth.pid.0=0x0040
+leonardoeth.vid.1=0x2a03
+leonardoeth.pid.1=0x8040
+
+leonardoeth.upload.tool=avrdude
+leonardoeth.upload.protocol=avr109
+leonardoeth.upload.maximum_size=28672
+leonardoeth.upload.maximum_data_size=2560
+leonardoeth.upload.speed=57600
+leonardoeth.upload.disable_flushing=true
+leonardoeth.upload.use_1200bps_touch=true
+leonardoeth.upload.wait_for_upload_port=true
+
+leonardoeth.bootloader.tool=avrdude
+leonardoeth.bootloader.low_fuses=0xff
+leonardoeth.bootloader.high_fuses=0xd8
+leonardoeth.bootloader.extended_fuses=0xcb
+leonardoeth.bootloader.file=caterina/Caterina-LeonardoEthernet.hex
+leonardoeth.bootloader.unlock_bits=0x3F
+leonardoeth.bootloader.lock_bits=0x2F
+
+leonardoeth.build.mcu=atmega32u4
+leonardoeth.build.f_cpu=16000000L
+leonardoeth.build.vid=0x2a03
+leonardoeth.build.pid=0x8040
+leonardoeth.build.usb_product="Arduino Leonardo ETH"
+leonardoeth.build.board=AVR_LEONARDO_ETH
+leonardoeth.build.core=arduino
+leonardoeth.build.variant=leonardo
+leonardoeth.build.extra_flags={build.usb_flags}
+
+leonardoeth.build.optimization_flags=-Os
+
+leonardoeth.menu.optimization.size=Size (Os)
+leonardoeth.menu.optimization.size.build.optimization_flags=-Os
+leonardoeth.menu.optimization.balance=Balance (O2)
+leonardoeth.menu.optimization.balance.build.optimization_flags=-O2
+leonardoeth.menu.optimization.speed=Speed (O3)
+leonardoeth.menu.optimization.speed.build.optimization_flags=-O3
+
+leonardoeth.build.serial_flags=-DSerial=Serial1
+
+leonardoeth.menu.defaultserial.hwserial=Hardware Serial (aka Serial1)
+leonardoeth.menu.defaultserial.hwserial.build.serial_flags=-DSerial=Serial1
+leonardoeth.menu.defaultserial.vserial1=Virtual Serial 1 (SerialU1)
+leonardoeth.menu.defaultserial.vserial1.build.serial_flags=-DSerial=SerialU1
+leonardoeth.menu.defaultserial.vserial2=Virtual Serial 2 (SerialU2)
+leonardoeth.menu.defaultserial.vserial2.build.serial_flags=-DSerial=SerialU2
+
+leonardoeth.menu.experimentalsavings.safest=No extra parameters (Safest)
+leonardoeth.menu.experimentalsavings.safest.build.savings_flags=
+leonardoeth.menu.experimentalsavings.knowngood=-fno-devirtualize -fno-use-cxa-atexit (Known to work)
+leonardoeth.menu.experimentalsavings.knowngood.build.savings_flags=-fno-devirtualize -fno-use-cxa-atexit
+leonardoeth.menu.experimentalsavings.novirt=-fno-devirtualize (Should be safe)
+leonardoeth.menu.experimentalsavings.novirt.build.savings_flags=-fno-devirtualize
+
+##############################################################
+
+esplora.name=Arduino Esplora (LUFA)
+esplora.vid.0=0x2341
+esplora.pid.0=0x003C
+esplora.vid.1=0x2341
+esplora.pid.1=0x803C
+esplora.vid.2=0x2A03
+esplora.pid.2=0x003C
+esplora.vid.3=0x2A03
+esplora.pid.3=0x803C
+
+esplora.upload.tool=avrdude
+esplora.upload.protocol=avr109
+esplora.upload.maximum_size=28672
+esplora.upload.maximum_data_size=2560
+esplora.upload.speed=57600
+esplora.upload.disable_flushing=true
+esplora.upload.use_1200bps_touch=true
+esplora.upload.wait_for_upload_port=true
+
+esplora.bootloader.tool=avrdude
+esplora.bootloader.low_fuses=0xff
+esplora.bootloader.high_fuses=0xd8
+esplora.bootloader.extended_fuses=0xcb
+esplora.bootloader.file=caterina/Caterina-Esplora.hex
+esplora.bootloader.unlock_bits=0x3F
+esplora.bootloader.lock_bits=0x2F
+
+esplora.build.mcu=atmega32u4
+esplora.build.f_cpu=16000000L
+esplora.build.vid=0x2341
+esplora.build.pid=0x803c
+esplora.build.usb_product="Arduino Esplora"
+esplora.build.board=AVR_ESPLORA
+esplora.build.core=arduino
+esplora.build.variant=leonardo
+esplora.build.extra_flags={build.usb_flags}
+
+esplora.build.optimization_flags=-Os
+
+esplora.menu.optimization.size=Size (Os)
+esplora.menu.optimization.size.build.optimization_flags=-Os
+esplora.menu.optimization.balance=Balance (O2)
+esplora.menu.optimization.balance.build.optimization_flags=-O2
+esplora.menu.optimization.speed=Speed (O3)
+esplora.menu.optimization.speed.build.optimization_flags=-O3
+
+esplora.build.serial_flags=-DSerial=Serial1
+
+esplora.menu.defaultserial.hwserial=Hardware Serial (aka Serial1)
+esplora.menu.defaultserial.hwserial.build.serial_flags=-DSerial=Serial1
+esplora.menu.defaultserial.vserial1=Virtual Serial 1 (SerialU1)
+esplora.menu.defaultserial.vserial1.build.serial_flags=-DSerial=SerialU1
+esplora.menu.defaultserial.vserial2=Virtual Serial 2 (SerialU2)
+esplora.menu.defaultserial.vserial2.build.serial_flags=-DSerial=SerialU2
+
+esplora.menu.experimentalsavings.safest=No extra parameters (Safest)
+esplora.menu.experimentalsavings.safest.build.savings_flags=
+esplora.menu.experimentalsavings.knowngood=-fno-devirtualize -fno-use-cxa-atexit (Known to work)
+esplora.menu.experimentalsavings.knowngood.build.savings_flags=-fno-devirtualize -fno-use-cxa-atexit
+esplora.menu.experimentalsavings.novirt=-fno-devirtualize (Should be safe)
+esplora.menu.experimentalsavings.novirt.build.savings_flags=-fno-devirtualize
+
+
+##############################################################
+
+LilyPadUSB.name=LilyPad Arduino USB (LUFA)
+LilyPadUSB.vid.0=0x1B4F
+LilyPadUSB.pid.0=0x9207
+LilyPadUSB.vid.1=0x1B4F
+LilyPadUSB.pid.1=0x9208
+
+LilyPadUSB.upload.tool=avrdude
+LilyPadUSB.upload.protocol=avr109
+LilyPadUSB.upload.maximum_size=28672
+LilyPadUSB.upload.maximum_data_size=2560
+LilyPadUSB.upload.speed=57600
+LilyPadUSB.upload.disable_flushing=true
+LilyPadUSB.upload.use_1200bps_touch=true
+LilyPadUSB.upload.wait_for_upload_port=true
+
+LilyPadUSB.bootloader.tool=avrdude
+LilyPadUSB.bootloader.low_fuses=0xff
+LilyPadUSB.bootloader.high_fuses=0xd8
+LilyPadUSB.bootloader.extended_fuses=0xce
+LilyPadUSB.bootloader.file=caterina-LilyPadUSB/Caterina-LilyPadUSB.hex
+LilyPadUSB.bootloader.unlock_bits=0x3F
+LilyPadUSB.bootloader.lock_bits=0x2F
+
+LilyPadUSB.build.mcu=atmega32u4
+LilyPadUSB.build.f_cpu=8000000L
+LilyPadUSB.build.vid=0x1B4F
+LilyPadUSB.build.pid=0x9208
+LilyPadUSB.build.usb_product="LilyPad USB"
+LilyPadUSB.build.board=AVR_LILYPAD_USB
+LilyPadUSB.build.core=arduino
+LilyPadUSB.build.variant=leonardo
+LilyPadUSB.build.extra_flags={build.usb_flags}
+
+LilyPadUSB.build.optimization_flags=-Os
+
+LilyPadUSB.menu.optimization.size=Size (Os)
+LilyPadUSB.menu.optimization.size.build.optimization_flags=-Os
+LilyPadUSB.menu.optimization.balance=Balance (O2)
+LilyPadUSB.menu.optimization.balance.build.optimization_flags=-O2
+LilyPadUSB.menu.optimization.speed=Speed (O3)
+LilyPadUSB.menu.optimization.speed.build.optimization_flags=-O3
+
+LilyPadUSB.build.serial_flags=-DSerial=Serial1
+
+LilyPadUSB.menu.defaultserial.hwserial=Hardware Serial (aka Serial1)
+LilyPadUSB.menu.defaultserial.hwserial.build.serial_flags=-DSerial=Serial1
+LilyPadUSB.menu.defaultserial.vserial1=Virtual Serial 1 (SerialU1)
+LilyPadUSB.menu.defaultserial.vserial1.build.serial_flags=-DSerial=SerialU1
+LilyPadUSB.menu.defaultserial.vserial2=Virtual Serial 2 (SerialU2)
+LilyPadUSB.menu.defaultserial.vserial2.build.serial_flags=-DSerial=SerialU2
+
+LilyPadUSB.menu.experimentalsavings.safest=No extra parameters (Safest)
+LilyPadUSB.menu.experimentalsavings.safest.build.savings_flags=
+LilyPadUSB.menu.experimentalsavings.knowngood=-fno-devirtualize -fno-use-cxa-atexit (Known to work)
+LilyPadUSB.menu.experimentalsavings.knowngood.build.savings_flags=-fno-devirtualize -fno-use-cxa-atexit
+LilyPadUSB.menu.experimentalsavings.novirt=-fno-devirtualize (Should be safe)
+LilyPadUSB.menu.experimentalsavings.novirt.build.savings_flags=-fno-devirtualize
+
+
+##############################################################
+
+robotControl.name=Arduino Robot Control (LUFA)
+robotControl.vid.0=0x2341
+robotControl.pid.0=0x0038
+robotControl.vid.1=0x2341
+robotControl.pid.1=0x8038
+robotControl.vid.2=0x2A03
+robotControl.pid.2=0x0038
+robotControl.vid.3=0x2A03
+robotControl.pid.3=0x8038
+
+robotControl.upload.tool=avrdude
+robotControl.upload.protocol=avr109
+robotControl.upload.maximum_size=28672
+robotControl.upload.maximum_data_size=2560
+robotControl.upload.speed=57600
+robotControl.upload.disable_flushing=true
+robotControl.upload.use_1200bps_touch=true
+robotControl.upload.wait_for_upload_port=true
+
+robotControl.bootloader.tool=avrdude
+robotControl.bootloader.low_fuses=0xff
+robotControl.bootloader.high_fuses=0xd8
+robotControl.bootloader.extended_fuses=0xcb
+robotControl.bootloader.file=caterina-Arduino_Robot/Caterina-Robot-Control.hex
+robotControl.bootloader.unlock_bits=0x3F
+robotControl.bootloader.lock_bits=0x2F
+
+robotControl.build.mcu=atmega32u4
+robotControl.build.f_cpu=16000000L
+robotControl.build.vid=0x2341
+robotControl.build.pid=0x8038
+robotControl.build.usb_product="Robot Control"
+robotControl.build.board=AVR_ROBOT_CONTROL
+robotControl.build.core=arduino
+robotControl.build.variant=robot_control
+robotControl.build.extra_flags={build.usb_flags}
+
+robotControl.build.optimization_flags=-Os
+
+robotControl.menu.optimization.size=Size (Os)
+robotControl.menu.optimization.size.build.optimization_flags=-Os
+robotControl.menu.optimization.balance=Balance (O2)
+robotControl.menu.optimization.balance.build.optimization_flags=-O2
+robotControl.menu.optimization.speed=Speed (O3)
+robotControl.menu.optimization.speed.build.optimization_flags=-O3
+
+robotControl.build.serial_flags=-DSerial=Serial1
+
+robotControl.menu.defaultserial.hwserial=Hardware Serial (aka Serial1)
+robotControl.menu.defaultserial.hwserial.build.serial_flags=-DSerial=Serial1
+robotControl.menu.defaultserial.vserial1=Virtual Serial 1 (SerialU1)
+robotControl.menu.defaultserial.vserial1.build.serial_flags=-DSerial=SerialU1
+robotControl.menu.defaultserial.vserial2=Virtual Serial 2 (SerialU2)
+robotControl.menu.defaultserial.vserial2.build.serial_flags=-DSerial=SerialU2
+
+robotControl.menu.experimentalsavings.safest=No extra parameters (Safest)
+robotControl.menu.experimentalsavings.safest.build.savings_flags=
+robotControl.menu.experimentalsavings.knowngood=-fno-devirtualize -fno-use-cxa-atexit (Known to work)
+robotControl.menu.experimentalsavings.knowngood.build.savings_flags=-fno-devirtualize -fno-use-cxa-atexit
+robotControl.menu.experimentalsavings.novirt=-fno-devirtualize (Should be safe)
+robotControl.menu.experimentalsavings.novirt.build.savings_flags=-fno-devirtualize
+
+
+##############################################################
+
+robotMotor.name=Arduino Robot Motor (LUFA)
+robotMotor.vid.0=0x2341
+robotMotor.pid.0=0x0039
+robotMotor.vid.1=0x2341
+robotMotor.pid.1=0x8039
+robotMotor.vid.2=0x2A03
+robotMotor.pid.2=0x0039
+robotMotor.vid.3=0x2A03
+robotMotor.pid.3=0x8039
+
+robotMotor.upload.tool=avrdude
+robotMotor.upload.protocol=avr109
+robotMotor.upload.maximum_size=28672
+robotMotor.upload.maximum_data_size=2560
+robotMotor.upload.speed=57600
+robotMotor.upload.disable_flushing=true
+robotMotor.upload.use_1200bps_touch=true
+robotMotor.upload.wait_for_upload_port=true
+
+robotMotor.bootloader.tool=avrdude
+robotMotor.bootloader.low_fuses=0xff
+robotMotor.bootloader.high_fuses=0xd8
+robotMotor.bootloader.extended_fuses=0xcb
+robotMotor.bootloader.file=caterina-Arduino_Robot/Caterina-Robot-Motor.hex
+robotMotor.bootloader.unlock_bits=0x3F
+robotMotor.bootloader.lock_bits=0x2F
+
+robotMotor.build.mcu=atmega32u4
+robotMotor.build.f_cpu=16000000L
+robotMotor.build.vid=0x2341
+robotMotor.build.pid=0x8039
+robotMotor.build.usb_product="Robot Motor"
+robotMotor.build.board=AVR_ROBOT_MOTOR
+robotMotor.build.core=arduino
+robotMotor.build.variant=robot_motor
+robotMotor.build.extra_flags={build.usb_flags}
+
+robotMotor.build.optimization_flags=-Os
+
+robotMotor.menu.optimization.size=Size (Os)
+robotMotor.menu.optimization.size.build.optimization_flags=-Os
+robotMotor.menu.optimization.balance=Balance (O2)
+robotMotor.menu.optimization.balance.build.optimization_flags=-O2
+robotMotor.menu.optimization.speed=Speed (O3)
+robotMotor.menu.optimization.speed.build.optimization_flags=-O3
+
+robotMotor.build.serial_flags=-DSerial=Serial1
+
+robotMotor.menu.defaultserial.hwserial=Hardware Serial (aka Serial1)
+robotMotor.menu.defaultserial.hwserial.build.serial_flags=-DSerial=Serial1
+robotMotor.menu.defaultserial.vserial1=Virtual Serial 1 (SerialU1)
+robotMotor.menu.defaultserial.vserial1.build.serial_flags=-DSerial=SerialU1
+robotMotor.menu.defaultserial.vserial2=Virtual Serial 2 (SerialU2)
+robotMotor.menu.defaultserial.vserial2.build.serial_flags=-DSerial=SerialU2
+
+robotMotor.menu.experimentalsavings.safest=No extra parameters (Safest)
+robotMotor.menu.experimentalsavings.safest.build.savings_flags=
+robotMotor.menu.experimentalsavings.knowngood=-fno-devirtualize -fno-use-cxa-atexit (Known to work)
+robotMotor.menu.experimentalsavings.knowngood.build.savings_flags=-fno-devirtualize -fno-use-cxa-atexit
+robotMotor.menu.experimentalsavings.novirt=-fno-devirtualize (Should be safe)
+robotMotor.menu.experimentalsavings.novirt.build.savings_flags=-fno-devirtualize
+
+
+##############################################################
+
+# Adafruit Circuit Playground 32u4 w/Caterina Configuration
+circuitplay32u4cat.name=Adafruit Circuit Playground (LUFA)
+circuitplay32u4cat.bootloader.low_fuses=0xff
+circuitplay32u4cat.bootloader.high_fuses=0xd8
+circuitplay32u4cat.bootloader.extended_fuses=0xcb
+circuitplay32u4cat.bootloader.file=caterina/Caterina-Circuitplay32u4.hex
+circuitplay32u4cat.bootloader.unlock_bits=0x3F
+circuitplay32u4cat.bootloader.lock_bits=0x2F
+circuitplay32u4cat.bootloader.tool=avrdude
+circuitplay32u4cat.build.mcu=atmega32u4
+circuitplay32u4cat.build.f_cpu=8000000L
+circuitplay32u4cat.build.vid=0x239A
+circuitplay32u4cat.build.pid=0x8011
+circuitplay32u4cat.build.core=arduino
+circuitplay32u4cat.build.variant=circuitplay32u4
+circuitplay32u4cat.build.board=AVR_CIRCUITPLAY
+circuitplay32u4cat.build.usb_product="Circuit Playground"
+circuitplay32u4cat.build.usb_manufacturer="Adafruit"
+circuitplay32u4cat.build.extra_flags={build.usb_flags}
+circuitplay32u4cat.upload.protocol=avr109
+circuitplay32u4cat.upload.maximum_size=28672
+circuitplay32u4cat.upload.speed=57600
+circuitplay32u4cat.upload.disable_flushing=true
+circuitplay32u4cat.upload.use_1200bps_touch=true
+circuitplay32u4cat.upload.wait_for_upload_port=true
+circuitplay32u4cat.upload.tool=avrdude
+circuitplay32u4cat.vid.0=0x239A
+circuitplay32u4cat.pid.0=0x8011
+
+circuitplay32u4cat.build.optimization_flags=-Os
+
+circuitplay32u4cat.menu.optimization.size=Size (Os)
+circuitplay32u4cat.menu.optimization.size.build.optimization_flags=-Os
+circuitplay32u4cat.menu.optimization.balance=Balance (O2)
+circuitplay32u4cat.menu.optimization.balance.build.optimization_flags=-O2
+circuitplay32u4cat.menu.optimization.speed=Speed (O3)
+circuitplay32u4cat.menu.optimization.speed.build.optimization_flags=-O3
+
+circuitplay32u4cat.build.serial_flags=-DSerial=Serial1
+
+circuitplay32u4cat.menu.defaultserial.hwserial=Hardware Serial (aka Serial1)
+circuitplay32u4cat.menu.defaultserial.hwserial.build.serial_flags=-DSerial=Serial1
+circuitplay32u4cat.menu.defaultserial.vserial1=Virtual Serial 1 (SerialU1)
+circuitplay32u4cat.menu.defaultserial.vserial1.build.serial_flags=-DSerial=SerialU1
+circuitplay32u4cat.menu.defaultserial.vserial2=Virtual Serial 2 (SerialU2)
+circuitplay32u4cat.menu.defaultserial.vserial2.build.serial_flags=-DSerial=SerialU2
+
+circuitplay32u4cat.menu.experimentalsavings.safest=No extra parameters (Safest)
+circuitplay32u4cat.menu.experimentalsavings.safest.build.savings_flags=
+circuitplay32u4cat.menu.experimentalsavings.knowngood=-fno-devirtualize -fno-use-cxa-atexit (Known to work)
+circuitplay32u4cat.menu.experimentalsavings.knowngood.build.savings_flags=-fno-devirtualize -fno-use-cxa-atexit
+circuitplay32u4cat.menu.experimentalsavings.novirt=-fno-devirtualize (Should be safe)
+circuitplay32u4cat.menu.experimentalsavings.novirt.build.savings_flags=-fno-devirtualize
+
+
+##############################################################
+
+yunmini.name=Arduino Yún Mini (LUFA)
+yunmini.upload.via_ssh=true
+
+yunmini.vid.0=0x2a03
+yunmini.pid.0=0x0050
+yunmini.vid.1=0x2a03
+yunmini.pid.1=0x8050
+
+yunmini.upload.tool=avrdude
+yunmini.upload.protocol=avr109
+yunmini.upload.maximum_size=28672
+yunmini.upload.maximum_data_size=2560
+yunmini.upload.speed=57600
+yunmini.upload.disable_flushing=true
+yunmini.upload.use_1200bps_touch=true
+yunmini.upload.wait_for_upload_port=true
+
+yunmini.bootloader.tool=avrdude
+yunmini.bootloader.low_fuses=0xff
+yunmini.bootloader.high_fuses=0xd8
+yunmini.bootloader.extended_fuses=0xfb
+yunmini.bootloader.file=caterina/Caterina-YunMini.hex
+yunmini.bootloader.unlock_bits=0x3F
+yunmini.bootloader.lock_bits=0x2F
+
+yunmini.build.mcu=atmega32u4
+yunmini.build.f_cpu=16000000L
+yunmini.build.vid=0x2a03
+yunmini.build.pid=0x8050
+yunmini.build.usb_product="Arduino Yún Mini"
+yunmini.build.board=AVR_YUNMINI
+yunmini.build.core=arduino
+yunmini.build.variant=yun
+yunmini.build.extra_flags={build.usb_flags}
+
+yunmini.build.optimization_flags=-Os
+
+yunmini.menu.optimization.size=Size (Os)
+yunmini.menu.optimization.size.build.optimization_flags=-Os
+yunmini.menu.optimization.balance=Balance (O2)
+yunmini.menu.optimization.balance.build.optimization_flags=-O2
+yunmini.menu.optimization.speed=Speed (O3)
+yunmini.menu.optimization.speed.build.optimization_flags=-O3
+
+yunmini.build.serial_flags=-DSerial=Serial1
+
+yunmini.menu.defaultserial.hwserial=Hardware Serial (aka Serial1)
+yunmini.menu.defaultserial.hwserial.build.serial_flags=-DSerial=Serial1
+yunmini.menu.defaultserial.vserial1=Virtual Serial 1 (SerialU1)
+yunmini.menu.defaultserial.vserial1.build.serial_flags=-DSerial=SerialU1
+yunmini.menu.defaultserial.vserial2=Virtual Serial 2 (SerialU2)
+yunmini.menu.defaultserial.vserial2.build.serial_flags=-DSerial=SerialU2
+
+yunmini.menu.experimentalsavings.safest=No extra parameters (Safest)
+yunmini.menu.experimentalsavings.safest.build.savings_flags=
+yunmini.menu.experimentalsavings.knowngood=-fno-devirtualize -fno-use-cxa-atexit (Known to work)
+yunmini.menu.experimentalsavings.knowngood.build.savings_flags=-fno-devirtualize -fno-use-cxa-atexit
+yunmini.menu.experimentalsavings.novirt=-fno-devirtualize (Should be safe)
+yunmini.menu.experimentalsavings.novirt.build.savings_flags=-fno-devirtualize
+
+
+##############################################################
+
+chiwawa.name=Arduino Industrial 101 (LUFA)
+chiwawa.upload.via_ssh=true
+
+chiwawa.vid.0=0x2a03
+chiwawa.pid.0=0x0056
+chiwawa.vid.1=0x2a03
+chiwawa.pid.1=0x8056
+
+chiwawa.upload.tool=avrdude
+chiwawa.upload.protocol=avr109
+chiwawa.upload.maximum_size=28672
+chiwawa.upload.maximum_data_size=2560
+chiwawa.upload.speed=57600
+chiwawa.upload.disable_flushing=true
+chiwawa.upload.use_1200bps_touch=true
+chiwawa.upload.wait_for_upload_port=true
+
+chiwawa.bootloader.tool=avrdude
+chiwawa.bootloader.low_fuses=0xff
+chiwawa.bootloader.high_fuses=0xd8
+chiwawa.bootloader.extended_fuses=0xfb
+chiwawa.bootloader.file=caterina/Caterina-Industrial101.hex
+chiwawa.bootloader.unlock_bits=0x3F
+chiwawa.bootloader.lock_bits=0x2F
+
+chiwawa.build.mcu=atmega32u4
+chiwawa.build.f_cpu=16000000L
+chiwawa.build.vid=0x2a03
+chiwawa.build.pid=0x8056
+chiwawa.build.usb_product="Arduino Industrial 101"
+chiwawa.build.board=AVR_INDUSTRIAL101
+chiwawa.build.core=arduino
+chiwawa.build.variant=yun
+chiwawa.build.extra_flags={build.usb_flags}
+
+chiwawa.build.optimization_flags=-Os
+
+chiwawa.menu.optimization.size=Size (Os)
+chiwawa.menu.optimization.size.build.optimization_flags=-Os
+chiwawa.menu.optimization.balance=Balance (O2)
+chiwawa.menu.optimization.balance.build.optimization_flags=-O2
+chiwawa.menu.optimization.speed=Speed (O3)
+chiwawa.menu.optimization.speed.build.optimization_flags=-O3
+
+chiwawa.build.serial_flags=-DSerial=Serial1
+
+chiwawa.menu.defaultserial.hwserial=Hardware Serial (aka Serial1)
+chiwawa.menu.defaultserial.hwserial.build.serial_flags=-DSerial=Serial1
+chiwawa.menu.defaultserial.vserial1=Virtual Serial 1 (SerialU1)
+chiwawa.menu.defaultserial.vserial1.build.serial_flags=-DSerial=SerialU1
+chiwawa.menu.defaultserial.vserial2=Virtual Serial 2 (SerialU2)
+chiwawa.menu.defaultserial.vserial2.build.serial_flags=-DSerial=SerialU2
+
+chiwawa.menu.experimentalsavings.safest=No extra parameters (Safest)
+chiwawa.menu.experimentalsavings.safest.build.savings_flags=
+chiwawa.menu.experimentalsavings.knowngood=-fno-devirtualize -fno-use-cxa-atexit (Known to work)
+chiwawa.menu.experimentalsavings.knowngood.build.savings_flags=-fno-devirtualize -fno-use-cxa-atexit
+chiwawa.menu.experimentalsavings.novirt=-fno-devirtualize (Should be safe)
+chiwawa.menu.experimentalsavings.novirt.build.savings_flags=-fno-devirtualize
+
+
+##############################################################
+
+one.name=Linino One (LUFA)
+one.upload.via_ssh=true
+
+one.vid.0=0x2a03
+one.pid.0=0x0001
+one.vid.1=0x2a03
+one.pid.1=0x8001
+
+one.upload.tool=avrdude
+one.upload.protocol=avr109
+one.upload.maximum_size=28672
+one.upload.maximum_data_size=2560
+one.upload.speed=57600
+one.upload.disable_flushing=true
+one.upload.use_1200bps_touch=true
+one.upload.wait_for_upload_port=true
+
+one.bootloader.tool=avrdude
+one.bootloader.low_fuses=0xff
+one.bootloader.high_fuses=0xd8
+one.bootloader.extended_fuses=0xfb
+one.bootloader.file=caterina/Caterina-LininoOne.hex
+one.bootloader.unlock_bits=0x3F
+one.bootloader.lock_bits=0x2F
+
+one.build.mcu=atmega32u4
+one.build.f_cpu=16000000L
+one.build.vid=0x2a03
+one.build.pid=0x8001
+one.build.usb_product="Linino One"
+one.build.board=AVR_LININO_ONE
+one.build.core=arduino
+one.build.variant=yun
+one.build.extra_flags={build.usb_flags}
+
+one.build.optimization_flags=-Os
+
+one.menu.optimization.size=Size (Os)
+one.menu.optimization.size.build.optimization_flags=-Os
+one.menu.optimization.balance=Balance (O2)
+one.menu.optimization.balance.build.optimization_flags=-O2
+one.menu.optimization.speed=Speed (O3)
+one.menu.optimization.speed.build.optimization_flags=-O3
+
+one.build.serial_flags=-DSerial=Serial1
+
+one.menu.defaultserial.hwserial=Hardware Serial (aka Serial1)
+one.menu.defaultserial.hwserial.build.serial_flags=-DSerial=Serial1
+one.menu.defaultserial.vserial1=Virtual Serial 1 (SerialU1)
+one.menu.defaultserial.vserial1.build.serial_flags=-DSerial=SerialU1
+one.menu.defaultserial.vserial2=Virtual Serial 2 (SerialU2)
+one.menu.defaultserial.vserial2.build.serial_flags=-DSerial=SerialU2
+
+one.menu.experimentalsavings.safest=No extra parameters (Safest)
+one.menu.experimentalsavings.safest.build.savings_flags=
+one.menu.experimentalsavings.knowngood=-fno-devirtualize -fno-use-cxa-atexit (Known to work)
+one.menu.experimentalsavings.knowngood.build.savings_flags=-fno-devirtualize -fno-use-cxa-atexit
+one.menu.experimentalsavings.novirt=-fno-devirtualize (Should be safe)
+one.menu.experimentalsavings.novirt.build.savings_flags=-fno-devirtualize
+
 
 ##############################################################
 
@@ -279,163 +1007,6 @@ yun.build.extra_flags={build.usb_flags}
 
 ##############################################################
 
-leonardo.name=Arduino Leonardo (LUFA)
-leonardo.vid.0=0x2341
-leonardo.pid.0=0x0036
-leonardo.vid.1=0x2341
-leonardo.pid.1=0x8036
-leonardo.vid.2=0x2A03
-leonardo.pid.2=0x0036
-leonardo.vid.3=0x2A03
-leonardo.pid.3=0x8036
-
-leonardo.upload.tool=avrdude
-leonardo.upload.protocol=avr109
-leonardo.upload.maximum_size=28672
-leonardo.upload.maximum_data_size=2560
-leonardo.upload.speed=57600
-leonardo.upload.disable_flushing=true
-leonardo.upload.use_1200bps_touch=true
-leonardo.upload.wait_for_upload_port=true
-
-leonardo.bootloader.tool=avrdude
-leonardo.bootloader.low_fuses=0xff
-leonardo.bootloader.high_fuses=0xd8
-leonardo.bootloader.extended_fuses=0xcb
-leonardo.bootloader.file=caterina/Caterina-Leonardo.hex
-leonardo.bootloader.unlock_bits=0x3F
-leonardo.bootloader.lock_bits=0x2F
-
-leonardo.build.mcu=atmega32u4
-leonardo.build.f_cpu=16000000L
-leonardo.build.vid=0x2341
-leonardo.build.pid=0x8036
-leonardo.build.usb_product="Arduino Leonardo"
-leonardo.build.board=AVR_LEONARDO
-leonardo.build.core=arduino
-leonardo.build.variant=leonardo
-leonardo.build.extra_flags={build.usb_flags}
-
-##############################################################
-
-leonardoeth.name=Arduino Leonardo ETH (LUFA)
-leonardoeth.vid.0=0x2a03
-leonardoeth.pid.0=0x0040
-leonardoeth.vid.1=0x2a03
-leonardoeth.pid.1=0x8040
-
-leonardoeth.upload.tool=avrdude
-leonardoeth.upload.protocol=avr109
-leonardoeth.upload.maximum_size=28672
-leonardoeth.upload.maximum_data_size=2560
-leonardoeth.upload.speed=57600
-leonardoeth.upload.disable_flushing=true
-leonardoeth.upload.use_1200bps_touch=true
-leonardoeth.upload.wait_for_upload_port=true
-
-leonardoeth.bootloader.tool=avrdude
-leonardoeth.bootloader.low_fuses=0xff
-leonardoeth.bootloader.high_fuses=0xd8
-leonardoeth.bootloader.extended_fuses=0xcb
-leonardoeth.bootloader.file=caterina/Caterina-LeonardoEthernet.hex
-leonardoeth.bootloader.unlock_bits=0x3F
-leonardoeth.bootloader.lock_bits=0x2F
-
-leonardoeth.build.mcu=atmega32u4
-leonardoeth.build.f_cpu=16000000L
-leonardoeth.build.vid=0x2a03
-leonardoeth.build.pid=0x8040
-leonardoeth.build.usb_product="Arduino Leonardo ETH"
-leonardoeth.build.board=AVR_LEONARDO_ETH
-leonardoeth.build.core=arduino
-leonardoeth.build.variant=leonardo
-leonardoeth.build.extra_flags={build.usb_flags}
-
-##############################################################
-
-micro.name=Arduino Micro (LUFA)
-
-micro.vid.0=0x2341
-micro.pid.0=0x0037
-micro.vid.1=0x2341
-micro.pid.1=0x8037
-micro.vid.2=0x2A03
-micro.pid.2=0x0037
-micro.vid.3=0x2A03
-micro.pid.3=0x8037
-micro.vid.4=0x2341
-micro.pid.4=0x0237
-micro.vid.5=0x2341
-micro.pid.5=0x8237
-
-micro.upload.tool=avrdude
-micro.upload.protocol=avr109
-micro.upload.maximum_size=28672
-micro.upload.maximum_data_size=2560
-micro.upload.speed=57600
-micro.upload.disable_flushing=true
-micro.upload.use_1200bps_touch=true
-micro.upload.wait_for_upload_port=true
-
-micro.bootloader.tool=avrdude
-micro.bootloader.low_fuses=0xff
-micro.bootloader.high_fuses=0xd8
-micro.bootloader.extended_fuses=0xcb
-micro.bootloader.file=caterina/Caterina-Micro.hex
-micro.bootloader.unlock_bits=0x3F
-micro.bootloader.lock_bits=0x2F
-
-micro.build.mcu=atmega32u4
-micro.build.f_cpu=16000000L
-micro.build.vid=0x2341
-micro.build.pid=0x8037
-micro.build.usb_product="Arduino Micro"
-micro.build.board=AVR_MICRO
-micro.build.core=arduino
-micro.build.variant=micro
-micro.build.extra_flags={build.usb_flags}
-
-##############################################################
-
-esplora.name=Arduino Esplora (LUFA)
-esplora.vid.0=0x2341
-esplora.pid.0=0x003C
-esplora.vid.1=0x2341
-esplora.pid.1=0x803C
-esplora.vid.2=0x2A03
-esplora.pid.2=0x003C
-esplora.vid.3=0x2A03
-esplora.pid.3=0x803C
-
-esplora.upload.tool=avrdude
-esplora.upload.protocol=avr109
-esplora.upload.maximum_size=28672
-esplora.upload.maximum_data_size=2560
-esplora.upload.speed=57600
-esplora.upload.disable_flushing=true
-esplora.upload.use_1200bps_touch=true
-esplora.upload.wait_for_upload_port=true
-
-esplora.bootloader.tool=avrdude
-esplora.bootloader.low_fuses=0xff
-esplora.bootloader.high_fuses=0xd8
-esplora.bootloader.extended_fuses=0xcb
-esplora.bootloader.file=caterina/Caterina-Esplora.hex
-esplora.bootloader.unlock_bits=0x3F
-esplora.bootloader.lock_bits=0x2F
-
-esplora.build.mcu=atmega32u4
-esplora.build.f_cpu=16000000L
-esplora.build.vid=0x2341
-esplora.build.pid=0x803c
-esplora.build.usb_product="Arduino Esplora"
-esplora.build.board=AVR_ESPLORA
-esplora.build.core=arduino
-esplora.build.variant=leonardo
-esplora.build.extra_flags={build.usb_flags}
-
-##############################################################
-
 #mini.name=Arduino Mini ((LUFA not supported))
 
 #mini.upload.tool=avrdude
@@ -569,41 +1140,6 @@ esplora.build.extra_flags={build.usb_flags}
 #bt.menu.cpu.atmega168.bootloader.file=bt/ATmegaBOOT_168.hex
 
 #bt.menu.cpu.atmega168.build.mcu=atmega168
-
-##############################################################
-
-LilyPadUSB.name=LilyPad Arduino USB (LUFA)
-LilyPadUSB.vid.0=0x1B4F
-LilyPadUSB.pid.0=0x9207
-LilyPadUSB.vid.1=0x1B4F
-LilyPadUSB.pid.1=0x9208
-
-LilyPadUSB.upload.tool=avrdude
-LilyPadUSB.upload.protocol=avr109
-LilyPadUSB.upload.maximum_size=28672
-LilyPadUSB.upload.maximum_data_size=2560
-LilyPadUSB.upload.speed=57600
-LilyPadUSB.upload.disable_flushing=true
-LilyPadUSB.upload.use_1200bps_touch=true
-LilyPadUSB.upload.wait_for_upload_port=true
-
-LilyPadUSB.bootloader.tool=avrdude
-LilyPadUSB.bootloader.low_fuses=0xff
-LilyPadUSB.bootloader.high_fuses=0xd8
-LilyPadUSB.bootloader.extended_fuses=0xce
-LilyPadUSB.bootloader.file=caterina-LilyPadUSB/Caterina-LilyPadUSB.hex
-LilyPadUSB.bootloader.unlock_bits=0x3F
-LilyPadUSB.bootloader.lock_bits=0x2F
-
-LilyPadUSB.build.mcu=atmega32u4
-LilyPadUSB.build.f_cpu=8000000L
-LilyPadUSB.build.vid=0x1B4F
-LilyPadUSB.build.pid=0x9208
-LilyPadUSB.build.usb_product="LilyPad USB"
-LilyPadUSB.build.board=AVR_LILYPAD_USB
-LilyPadUSB.build.core=arduino
-LilyPadUSB.build.variant=leonardo
-LilyPadUSB.build.extra_flags={build.usb_flags}
 
 ##############################################################
 
@@ -778,84 +1314,6 @@ LilyPadUSB.build.extra_flags={build.usb_flags}
 
 ##############################################################
 
-robotControl.name=Arduino Robot Control (LUFA)
-robotControl.vid.0=0x2341
-robotControl.pid.0=0x0038
-robotControl.vid.1=0x2341
-robotControl.pid.1=0x8038
-robotControl.vid.2=0x2A03
-robotControl.pid.2=0x0038
-robotControl.vid.3=0x2A03
-robotControl.pid.3=0x8038
-
-robotControl.upload.tool=avrdude
-robotControl.upload.protocol=avr109
-robotControl.upload.maximum_size=28672
-robotControl.upload.maximum_data_size=2560
-robotControl.upload.speed=57600
-robotControl.upload.disable_flushing=true
-robotControl.upload.use_1200bps_touch=true
-robotControl.upload.wait_for_upload_port=true
-
-robotControl.bootloader.tool=avrdude
-robotControl.bootloader.low_fuses=0xff
-robotControl.bootloader.high_fuses=0xd8
-robotControl.bootloader.extended_fuses=0xcb
-robotControl.bootloader.file=caterina-Arduino_Robot/Caterina-Robot-Control.hex
-robotControl.bootloader.unlock_bits=0x3F
-robotControl.bootloader.lock_bits=0x2F
-
-robotControl.build.mcu=atmega32u4
-robotControl.build.f_cpu=16000000L
-robotControl.build.vid=0x2341
-robotControl.build.pid=0x8038
-robotControl.build.usb_product="Robot Control"
-robotControl.build.board=AVR_ROBOT_CONTROL
-robotControl.build.core=arduino
-robotControl.build.variant=robot_control
-robotControl.build.extra_flags={build.usb_flags}
-
-##############################################################
-
-robotMotor.name=Arduino Robot Motor (LUFA)
-robotMotor.vid.0=0x2341
-robotMotor.pid.0=0x0039
-robotMotor.vid.1=0x2341
-robotMotor.pid.1=0x8039
-robotMotor.vid.2=0x2A03
-robotMotor.pid.2=0x0039
-robotMotor.vid.3=0x2A03
-robotMotor.pid.3=0x8039
-
-robotMotor.upload.tool=avrdude
-robotMotor.upload.protocol=avr109
-robotMotor.upload.maximum_size=28672
-robotMotor.upload.maximum_data_size=2560
-robotMotor.upload.speed=57600
-robotMotor.upload.disable_flushing=true
-robotMotor.upload.use_1200bps_touch=true
-robotMotor.upload.wait_for_upload_port=true
-
-robotMotor.bootloader.tool=avrdude
-robotMotor.bootloader.low_fuses=0xff
-robotMotor.bootloader.high_fuses=0xd8
-robotMotor.bootloader.extended_fuses=0xcb
-robotMotor.bootloader.file=caterina-Arduino_Robot/Caterina-Robot-Motor.hex
-robotMotor.bootloader.unlock_bits=0x3F
-robotMotor.bootloader.lock_bits=0x2F
-
-robotMotor.build.mcu=atmega32u4
-robotMotor.build.f_cpu=16000000L
-robotMotor.build.vid=0x2341
-robotMotor.build.pid=0x8039
-robotMotor.build.usb_product="Robot Motor"
-robotMotor.build.board=AVR_ROBOT_MOTOR
-robotMotor.build.core=arduino
-robotMotor.build.variant=robot_motor
-robotMotor.build.extra_flags={build.usb_flags}
-
-##############################################################
-
 #gemma.vid.0=0x2341
 #gemma.pid.0=0x0c9f
 
@@ -877,148 +1335,6 @@ robotMotor.build.extra_flags={build.usb_flags}
 
 #gemma.upload.tool=avrdude
 #gemma.upload.maximum_size=5310
-
-##############################################################
-
-# Adafruit Circuit Playground 32u4 w/Caterina Configuration
-circuitplay32u4cat.name=Adafruit Circuit Playground (LUFA)
-circuitplay32u4cat.bootloader.low_fuses=0xff
-circuitplay32u4cat.bootloader.high_fuses=0xd8
-circuitplay32u4cat.bootloader.extended_fuses=0xcb
-circuitplay32u4cat.bootloader.file=caterina/Caterina-Circuitplay32u4.hex
-circuitplay32u4cat.bootloader.unlock_bits=0x3F
-circuitplay32u4cat.bootloader.lock_bits=0x2F
-circuitplay32u4cat.bootloader.tool=avrdude
-circuitplay32u4cat.build.mcu=atmega32u4
-circuitplay32u4cat.build.f_cpu=8000000L
-circuitplay32u4cat.build.vid=0x239A
-circuitplay32u4cat.build.pid=0x8011
-circuitplay32u4cat.build.core=arduino
-circuitplay32u4cat.build.variant=circuitplay32u4
-circuitplay32u4cat.build.board=AVR_CIRCUITPLAY
-circuitplay32u4cat.build.usb_product="Circuit Playground"
-circuitplay32u4cat.build.usb_manufacturer="Adafruit"
-circuitplay32u4cat.build.extra_flags={build.usb_flags}
-circuitplay32u4cat.upload.protocol=avr109
-circuitplay32u4cat.upload.maximum_size=28672
-circuitplay32u4cat.upload.speed=57600
-circuitplay32u4cat.upload.disable_flushing=true
-circuitplay32u4cat.upload.use_1200bps_touch=true
-circuitplay32u4cat.upload.wait_for_upload_port=true
-circuitplay32u4cat.upload.tool=avrdude
-circuitplay32u4cat.vid.0=0x239A
-circuitplay32u4cat.pid.0=0x8011
-
-##############################################################
-
-yunmini.name=Arduino Yún Mini (LUFA)
-yunmini.upload.via_ssh=true
-
-yunmini.vid.0=0x2a03
-yunmini.pid.0=0x0050
-yunmini.vid.1=0x2a03
-yunmini.pid.1=0x8050
-
-yunmini.upload.tool=avrdude
-yunmini.upload.protocol=avr109
-yunmini.upload.maximum_size=28672
-yunmini.upload.maximum_data_size=2560
-yunmini.upload.speed=57600
-yunmini.upload.disable_flushing=true
-yunmini.upload.use_1200bps_touch=true
-yunmini.upload.wait_for_upload_port=true
-
-yunmini.bootloader.tool=avrdude
-yunmini.bootloader.low_fuses=0xff
-yunmini.bootloader.high_fuses=0xd8
-yunmini.bootloader.extended_fuses=0xfb
-yunmini.bootloader.file=caterina/Caterina-YunMini.hex
-yunmini.bootloader.unlock_bits=0x3F
-yunmini.bootloader.lock_bits=0x2F
-
-yunmini.build.mcu=atmega32u4
-yunmini.build.f_cpu=16000000L
-yunmini.build.vid=0x2a03
-yunmini.build.pid=0x8050
-yunmini.build.usb_product="Arduino Yún Mini"
-yunmini.build.board=AVR_YUNMINI
-yunmini.build.core=arduino
-yunmini.build.variant=yun
-yunmini.build.extra_flags={build.usb_flags}
-
-##############################################################
-
-chiwawa.name=Arduino Industrial 101 (LUFA)
-chiwawa.upload.via_ssh=true
-
-chiwawa.vid.0=0x2a03
-chiwawa.pid.0=0x0056
-chiwawa.vid.1=0x2a03
-chiwawa.pid.1=0x8056
-
-chiwawa.upload.tool=avrdude
-chiwawa.upload.protocol=avr109
-chiwawa.upload.maximum_size=28672
-chiwawa.upload.maximum_data_size=2560
-chiwawa.upload.speed=57600
-chiwawa.upload.disable_flushing=true
-chiwawa.upload.use_1200bps_touch=true
-chiwawa.upload.wait_for_upload_port=true
-
-chiwawa.bootloader.tool=avrdude
-chiwawa.bootloader.low_fuses=0xff
-chiwawa.bootloader.high_fuses=0xd8
-chiwawa.bootloader.extended_fuses=0xfb
-chiwawa.bootloader.file=caterina/Caterina-Industrial101.hex
-chiwawa.bootloader.unlock_bits=0x3F
-chiwawa.bootloader.lock_bits=0x2F
-
-chiwawa.build.mcu=atmega32u4
-chiwawa.build.f_cpu=16000000L
-chiwawa.build.vid=0x2a03
-chiwawa.build.pid=0x8056
-chiwawa.build.usb_product="Arduino Industrial 101"
-chiwawa.build.board=AVR_INDUSTRIAL101
-chiwawa.build.core=arduino
-chiwawa.build.variant=yun
-chiwawa.build.extra_flags={build.usb_flags}
-
-##############################################################
-
-one.name=Linino One (LUFA)
-one.upload.via_ssh=true
-
-one.vid.0=0x2a03
-one.pid.0=0x0001
-one.vid.1=0x2a03
-one.pid.1=0x8001
-
-one.upload.tool=avrdude
-one.upload.protocol=avr109
-one.upload.maximum_size=28672
-one.upload.maximum_data_size=2560
-one.upload.speed=57600
-one.upload.disable_flushing=true
-one.upload.use_1200bps_touch=true
-one.upload.wait_for_upload_port=true
-
-one.bootloader.tool=avrdude
-one.bootloader.low_fuses=0xff
-one.bootloader.high_fuses=0xd8
-one.bootloader.extended_fuses=0xfb
-one.bootloader.file=caterina/Caterina-LininoOne.hex
-one.bootloader.unlock_bits=0x3F
-one.bootloader.lock_bits=0x2F
-
-one.build.mcu=atmega32u4
-one.build.f_cpu=16000000L
-one.build.vid=0x2a03
-one.build.pid=0x8001
-one.build.usb_product="Linino One"
-one.build.board=AVR_LININO_ONE
-one.build.core=arduino
-one.build.variant=yun
-one.build.extra_flags={build.usb_flags}
 
 ##############################################################
 

--- a/platform.txt
+++ b/platform.txt
@@ -25,7 +25,12 @@ compiler.c.elf.flags={compiler.warning_flags} -Os -g -flto -fuse-linker-plugin -
 compiler.c.elf.cmd=avr-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp -flto -MMD
 compiler.cpp.cmd=avr-g++
-compiler.cpp.flags=-c -g -Os {compiler.warning_flags} -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -MMD -flto
+
+# psst, you can add "-fno-devirtualize" to this to get some space savings. but it might cause some issues? its supposed to be paired with "-fno-use-cxa-atexit"
+# so to get some space savings, append this to the end:
+# -fno-devirtualize -fno-use-cxa-atexit
+compiler.cpp.flags=-c -g -Os {compiler.warning_flags} -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -MMD -flto {build.savings_flags}
+
 compiler.ar.cmd=avr-gcc-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=avr-objcopy
@@ -36,8 +41,11 @@ compiler.ldflags=
 compiler.libraries.ldflags=
 compiler.size.cmd=avr-size
 
-# This can be overridden in boards.txt
+# These can be overridden in boards.txt
 build.extra_flags=
+build.serial_flags=
+build.optimization_flags=
+build.savings_flags=
 
 # These can be overridden in platform.local.txt
 compiler.c.extra_flags=
@@ -52,13 +60,13 @@ compiler.elf2hex.extra_flags=
 # --------------------
 
 ## Compile c files
-recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {build.serial_flags} {build.optimization_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile c++ files
-recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {build.serial_flags} {build.optimization_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile S files
-recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {build.serial_flags} {build.optimization_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Create archives
 # archive_file_path is needed for backwards compatibility with IDE 1.6.5 or older, IDE 1.6.6 or newer overrides this value
@@ -84,10 +92,10 @@ recipe.size.regex.eeprom=^(?:\.eeprom)\s+([0-9]+).*
 
 ## Preprocessor
 preproc.includes.flags=-w -x c++ -M -MG -MP
-recipe.preproc.includes="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.includes.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}"
+recipe.preproc.includes="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.includes.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {build.serial_flags} {build.optimization_flags} {includes} "{source_file}"
 
 preproc.macros.flags=-w -x c++ -E -CC
-recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.macros.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{preprocessed_file_path}"
+recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.macros.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {build.serial_flags} {build.optimization_flags} {includes} "{source_file}" -o "{preprocessed_file_path}"
 
 # AVR Uploader/Programmers tools
 # ------------------------------


### PR DESCRIPTION
Howdy, me again.

This is me bringing the extra QOL stuff I've made to my version of Arduino-LUFA to yours. 

Namely, setting `Serial` to `Serial1` by default, as projects/libraries that use Serial will just fail to compile, and I've found even doing a `#define Serial Serial1` and other crap before including libraries didn't help.

Also, I've exposed the Optimization levels (Os, O2, O3), with Size as the default (as it is normally). And an option I had in my Arch Linux install of Arduino that saves some space with Link-Time Optimization (LTO), but it seems a little iffy, so I left it off by default. 

Let me know if you see any issues!